### PR TITLE
Feature UART Gripper

### DIFF
--- a/.clang-format-compare.py
+++ b/.clang-format-compare.py
@@ -1,0 +1,56 @@
+## @file      .clang-format-compare.py
+#  @brief     Tool for comparing source files with a formatted variant in order to detect clang-formatting
+#  @author    Julian van Doorn
+#  @license   See LICENSE
+
+from subprocess import *
+from xml.etree import ElementTree
+from os import getcwd, path, walk
+from glob import glob
+from sys import exit, argv
+
+def isClangFormatted(fileDir):
+    pargs = [
+        "clang-format",
+        path.join(fileDir),
+        "--output-replacements-xml"
+    ]
+
+    raw_xml = Popen(pargs, stdout=PIPE).communicate()[0]
+
+    tree = ElementTree.fromstring(raw_xml) # if replacements is zero, that means it is already clang-formatted
+
+    return len(tree) == 0
+
+def getUnformattedFiles(folderDirs, filePatterns):
+    fileDirs = []
+
+    for dir in folderDirs:
+        for pattern in filePatterns:
+            fileDirs += [y for x in walk(dir) for y in glob(path.join(x[0], pattern))]
+
+    unformattedFiles = []
+
+    for dir in fileDirs:
+        if not isClangFormatted(dir):
+            unformattedFiles.append(dir)
+
+    return unformattedFiles
+
+def main():
+    unformattedFiles = getUnformattedFiles(argv[1:], ["*.cpp", "*.hpp"])
+
+    if len(unformattedFiles) > 0:
+        print("The following source files are not clang-formatted:")
+
+        for dir in unformattedFiles:
+            print(dir)
+
+        exit(1)
+
+    print("All source files are clang-formatted!")
+
+    exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_test/
 .vscode/
 .vscode/tasks.json
 .vscode/c_cpp_properties.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
+.vscode/
 .vscode/tasks.json
 .vscode/c_cpp_properties.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,30 @@
-language: c++
+language: generic
 sudo: required
-
-compiler:
-  - gcc
+dist: trusty
   
 python:
   - "2.7"
 
-install:
-  - sudo pip2 install lizard -q # Cyclomatic Complexity Check Tool
-
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise
     packages:
       - cmake
       - valgrind
+      - gcc-5
+      - g++-5
+      - clang-format-5.0
+
+install:
+  - sudo pip2 install lizard -q # Cyclomatic Complexity Check Tool
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc # Change symlinks of gcc to gcc-5
+  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++ # Change symlinks of g++ to g++-5
 
 before_script:
   - gcc --version
+  - g++ --version
   - python --version
   - cmake --version
   - valgrind --version

--- a/BuildModule.cmake
+++ b/BuildModule.cmake
@@ -1,4 +1,16 @@
-include (../../flags.cmake)
+include (${build_environment}/flags.cmake)
+
+set (sources ${sources}
+    src/main.cpp
+    src/wrap-hwlib.cpp
+    src/libc-stub.cpp
+    src/uart_connection.cpp
+    src/claw.cpp
+)
+
+add_definitions (-DBMPTK_TARGET_arduino_due
+                 -DBMPTK_TARGET=arduino_due
+                 -DBMPTK_BAUDRATE=19200)
 
 set (cxxflags
     "-Os"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,16 @@ cmake_minimum_required (VERSION 2.8.11)
 
 option (test_build "test_build" FALSE)
 
-include (Sources.cmake)
+# Toolchain:
+
+set (build_environment "$ENV{R2D2_BUILD_ENVIRONMENT}") # Your path to kvasir_toolchain
+
+if (build_environment)
+set (toolchain ${build_environment}/toolchain)
+else (build_environment)
+set (build_environment ../..)
+set (toolchain ../../toolchain)
+endif (build_environment)
 
 if (NOT ${test_build})
 set (CMAKE_TOOLCHAIN_FILE ${toolchain}/compilers/arm-none-eabi.cmake)
@@ -12,10 +21,13 @@ endif (NOT ${test_build})
 
 project (arduino-template CXX)
 
+include (Sources.cmake)
+
 set (build_test_enabled TRUE)
 set (unit_test_enabled TRUE)
 set (complexity_test_enabled TRUE)
 set (memcheck_enabled TRUE)
+set (clang_format_test_enabled TRUE)
 set (unit_test_main test/test_main.cpp)
 
 if (NOT ${test_build})

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -1,23 +1,9 @@
-# Toolchain:
-
-set (build_environment "$ENV{R2D2_BUILD_ENVIRONMENT}") # Your path to kvasir_toolchain
-
-if (build_environment)
-set (toolchain ${build_environment}/toolchain)
-else (build_environment)
-set (build_environment ../..)
-set (toolchain ../../toolchain)
-endif (build_environment)
-
 # Libraries:
 
 link_libraries (gcc)
 
 set (hwlib ${build_environment}/libraries/hwlib)
 include_directories (${hwlib}/library)
-add_definitions (-DBMPTK_TARGET_arduino_due
-                 -DBMPTK_TARGET=arduino_due
-                 -DBMPTK_BAUDRATE=19200)
 
 set (catch ${build_environment}/libraries/Catch2)
 include_directories (${catch}/single_include)
@@ -25,9 +11,5 @@ include_directories (${catch}/single_include)
 # Source Files:
 
 set (sources
-    src/wrap-hwlib.cpp
-    src/libc-stub.cpp
-    src/main.cpp
-    src/uart_connection.cpp
-    src/claw.cpp
+   
 )

--- a/TestModule.cmake
+++ b/TestModule.cmake
@@ -1,9 +1,24 @@
 include (CTest)
 
+include (${build_environment}/flags.cmake)
+
+include_directories (src/)
+
+add_definitions (-DBMPTK_TARGET_test
+                 -DBMPTK_TARGET=test
+                 -DBMPTK_BAUDRATE=19200)
+
+set (sources ${sources}
+    ${unit_test_main}
+    src/wrap-hwlib.cpp
+    src/libc-stub.cpp
+)
+
 set (build_test build_test)
 set (unit_test unit_test)
 set (memcheck memcheck)
 set (complexity_test complexity_test)
+set (clangformat_test clangformat_test)
 
 if (NOT DEFINED cyclomatic_complexity_warning)
 SET(cyclomatic_complexity_warning 10)
@@ -20,7 +35,7 @@ add_test (
 endif (build_test_enabled)
 
 if (unit_test_enabled)
-add_executable (${unit_test} ${unit_test_main})
+add_executable (${unit_test} ${unit_test_main} ${sources})
 
 add_test (
 	NAME ${unit_test}
@@ -53,6 +68,13 @@ set_tests_properties (
 )
 endif (UNIX AND memcheck_enabled)
 endif (test_build)
+
+if (clang_format_test_enabled)
+add_test (
+	NAME ${clangformat_test}
+	COMMAND python2 ${PROJECT_SOURCE_DIR}/.clang-format-compare.py ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/test
+)
+endif (clang_format_test_enabled)
 
 # The target that is compiled for:
 include (${toolchain}/targets/test/test.cmake)

--- a/src/claw.cpp
+++ b/src/claw.cpp
@@ -1,10 +1,8 @@
 #include "claw.hpp"
 
+
 void Claw::open() {
-    hwlib::cout << "Opening the claw..." << hwlib::endlRet;
-    hwlib::wait_ms(1000);
-    position = 100;
-    hwlib::cout << "Claw opened!" << hwlib::endlRet;
+    uartComm << "#n M2232 V0\n";
 }
 
 void Claw::openUntilReleased() {
@@ -22,12 +20,7 @@ void Claw::openUntilReleased() {
 }
 
 void Claw::close() {
-    hwlib::cout << "Closing the claw..." << hwlib::endlRet;
-
-    hwlib::wait_ms(1000);
-
-    position = 0;
-    hwlib::cout << "Claw closed!" << hwlib::endlRet;
+    uartComm << "#n M2232 V1\n";
 }
 
 void Claw::closeUntilGrabbed() {

--- a/src/claw.cpp
+++ b/src/claw.cpp
@@ -91,19 +91,16 @@ char* Claw::getUarmFirmwareVersion(char response[15]) {
 
         if (uartComm.available() > 0) {
             byteRead = uartComm.receive();
+            /// Read until the end line.
             if (byteRead != '\n' && responseIndex < 15) {
                 response[responseIndex++] = byteRead;
             } else {
                 break;
             }
-
-           
         }
-
     }
 
     response[responseIndex] = '\0';
-
     
     return response;
 }

--- a/src/claw.cpp
+++ b/src/claw.cpp
@@ -1,6 +1,5 @@
 #include "claw.hpp"
 
-
 void Claw::open() {
     uartComm << "#n M2232 V0\n";
 }
@@ -82,7 +81,7 @@ unsigned int Claw::getPosition() {
     return position;
 }
 
-char* Claw::getUarmFirmwareVersion(char response[15]) {
+char *Claw::getUarmFirmwareVersion(char response[15]) {
     uartComm << "#n P2203\n";
 
     int responseIndex = 0;
@@ -101,6 +100,6 @@ char* Claw::getUarmFirmwareVersion(char response[15]) {
     }
 
     response[responseIndex] = '\0';
-    
+
     return response;
 }

--- a/src/claw.cpp
+++ b/src/claw.cpp
@@ -81,3 +81,29 @@ void Claw::setPosition(unsigned int destPos) {
 unsigned int Claw::getPosition() {
     return position;
 }
+
+char* Claw::getUarmFirmwareVersion(char response[15]) {
+    uartComm << "#n P2203\n";
+
+    int responseIndex = 0;
+    while (true) {
+        char byteRead;
+
+        if (uartComm.available() > 0) {
+            byteRead = uartComm.receive();
+            if (byteRead != '\n' && responseIndex < 15) {
+                response[responseIndex++] = byteRead;
+            } else {
+                break;
+            }
+
+           
+        }
+
+    }
+
+    response[responseIndex] = '\0';
+
+    
+    return response;
+}

--- a/src/claw.hpp
+++ b/src/claw.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief     Interface for the uArm Swift Pro claw/gripper
- * @author    Wiebe van Breukelen
+ * @author    Wiebe van Breukelen & Sam Zandee
  * @license   See LICENSE
  */
 #ifndef CLAW_HPP

--- a/src/claw.hpp
+++ b/src/claw.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief     Interface for the uArm Swift Pro claw/gripper
- * @author    Wiebe van Breukelen & Sam Zandee
+ * @author    Wiebe van Breukelen, Sam Zandee
  * @license   See LICENSE
  */
 #ifndef CLAW_HPP
@@ -12,8 +12,22 @@
 
 class Claw {
   private:
+    /**
+     * @brief The current position of the claw
+     * 
+     */
     unsigned int position;
+
+    /**
+     * @brief UART connection to communicate with the uArm Swift Pro.
+     * 
+     */
     UARTConnection &uartComm;
+
+    /**
+     * @brief Used to check if an object has been grabbed/released by the robotic claw.
+     * 
+     */
     ClawSensing clawSensing;
 
   public:

--- a/src/claw.hpp
+++ b/src/claw.hpp
@@ -14,19 +14,19 @@ class Claw {
   private:
     /**
      * @brief The current position of the claw
-     * 
+     *
      */
     unsigned int position;
 
     /**
      * @brief UART connection to communicate with the uArm Swift Pro.
-     * 
+     *
      */
     UARTConnection &uartComm;
 
     /**
      * @brief Used to check if an object has been grabbed/released by the robotic claw.
-     * 
+     *
      */
     ClawSensing clawSensing;
 
@@ -106,11 +106,11 @@ class Claw {
 
     /**
      * @brief Get the version of the firmware currently running on the uArm.
-     * 
+     *
      * @param response Char buffer to write version string to.
      * @return char* Written char buffer.
      */
-    char* getUarmFirmwareVersion(char response[15]);
+    char *getUarmFirmwareVersion(char response[15]);
 };
 
 #endif

--- a/src/claw.hpp
+++ b/src/claw.hpp
@@ -103,6 +103,14 @@ class Claw {
      * @return unsigned int Current position of the robotic claw in the scale of 0-100.
      */
     unsigned int getPosition();
+
+    /**
+     * @brief Get the version of the firmware currently running on the uArm.
+     * 
+     * @param response Char buffer to write version string to.
+     * @return char* Written char buffer.
+     */
+    char* getUarmFirmwareVersion(char response[15]);
 };
 
 #endif

--- a/src/libc-stub.cpp
+++ b/src/libc-stub.cpp
@@ -1,3 +1,4 @@
 /// Pretend that we have a cstdlib to please kvasir-toolchain.
 extern "C" void __libc_init_array();
-extern "C" void __libc_init_array() { }
+extern "C" void __libc_init_array() {
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int main() {
     target::pin_in touchSensorLeft(target::pins::d4);
     target::pin_in touchSensorRight(target::pins::d5);
 
-    UARTConnection conn;
+    UARTConnection conn(115200, UARTController::ONE);
 
     conn.begin();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main() {
 
     UARTConnection conn(115200, UARTController::ONE, false);
     Claw claw(conn, touchSensorLeft, touchSensorRight);
-    
+
     conn.begin();
 
     hwlib::wait_ms(500);
@@ -38,7 +38,7 @@ int main() {
     claw.getUarmFirmwareVersion(fwVersion);
 
     hwlib::cout << fwVersion << hwlib::endlRet;
-   
+
     bool state = false;
     startMsReceive = hwlib::now_us() / 1000;
     startMsSend = hwlib::now_us() / 1000;
@@ -49,7 +49,7 @@ int main() {
 
             if (state) {
                 hwlib::cout << "Opening claw...\n";
-                
+
                 claw.open();
             } else {
                 hwlib::cout << "Closing claw...\n";
@@ -57,19 +57,18 @@ int main() {
             }
 
             state = !state;
-            
         }
 
         debugUarmRx(conn); /// Debugging purposes. You may remove this if you don't want the serial output of the uArm Swift Pro.
     }
 }
 
-
 /**
- * @brief If the developer would like to view the serial output of the uArm Swift Pro, they can place this function within the endless main loop.
- * 
+ * @brief If the developer would like to view the serial output of the uArm Swift Pro, they can place this function within the
+ * endless main loop.
+ *
  */
-inline void debugUarmRx (UARTConnection &conn) {
+inline void debugUarmRx(UARTConnection &conn) {
     if (conn.available() > 0 && (hwlib::now_us() / 1000) - startMsReceive > 30) {
         for (unsigned int i = 0; i < conn.available(); i++) {
             hwlib::cout << conn.receive();
@@ -78,4 +77,3 @@ inline void debugUarmRx (UARTConnection &conn) {
         startMsReceive = hwlib::now_us() / 1000;
     }
 }
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,16 @@ int main() {
     conn.begin();
 
     hwlib::wait_ms(500);
+
+    char fwVersion[15];
+    hwlib::cout << "Receiving firmware version... -> ";
+
+    /// Print the firmware version running on the claw.
+    /// If the claw is not probably connected, this function will hang forever.
+    /// In a further sprint, this should be fixed.
+    claw.getUarmFirmwareVersion(fwVersion);
+
+    hwlib::cout << fwVersion << hwlib::endlRet;
    
     bool state = false;
     startMsReceive = hwlib::now_us() / 1000;
@@ -68,3 +78,4 @@ inline void debugUarmRx (UARTConnection &conn) {
         startMsReceive = hwlib::now_us() / 1000;
     }
 }
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,36 +24,35 @@ int main() {
     target::pin_in touchSensorRight(target::pins::d5);
 
     UARTConnection conn(115200, UARTController::ONE);
+    hwlib::wait_ms(500);
+
+    long startMsReceive = hwlib::now_us() / 1000;
+    long startMsSend = hwlib::now_us() / 1000;
 
     conn.begin();
+    bool state = false;
 
-    conn.send('a');
-    conn.send("Hello World!");
+    while (true) {
+        if ((hwlib::now_us() / 1000) - startMsSend > 2500) {
+            startMsSend = hwlib::now_us() / 1000;
+            conn << "#n P2203\n"; // Getting version
 
-    hwlib::wait_ms(500);
-   
+            if (state) {
+                conn << "#n M2232 V0\n";
+            } else {
+                conn << "#n M2232 V1\n";
+            }
 
-    /**while (true) {
-        uartSendByte(0xA0);
+            state = !state;
+            
+        }
 
-        hwlib::wait_ms(200);
-    }**/
+        if (conn.available() > 0 && (hwlib::now_us() / 1000) - startMsReceive > 50) {
+            startMsReceive = hwlib::now_us() / 1000;
 
-    /**UARTCommunication uart;
-    Claw claw(uart, touchSensorLeft, touchSensorRight);
-
-    /// Perform some small mock tests.
-    claw.open();
-
-    hwlib::wait_ms(1000);
-
-    claw.close();
-
-    hwlib::wait_ms(1000);
-
-    claw.openUntilReleased();
-
-    hwlib::cout << "Actual position: " << claw.getPosition() << hwlib::endlRet;
-
-    return 0;**/
+            for (unsigned int i = 0; i < conn.available(); i++) {
+                hwlib::cout << conn.receive();
+            }
+        }
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,12 +48,19 @@ int main() {
             startMsSend = hwlib::now_us() / 1000;
 
             if (state) {
-                hwlib::cout << "Opening claw...\n";
+                hwlib::cout << "Opening claw..." << hwlib::endlRet;
 
                 claw.open();
+
+                hwlib::wait_ms(2000);
+                hwlib::cout << "Object detected!" << hwlib::endlRet;
             } else {
-                hwlib::cout << "Closing claw...\n";
+                hwlib::cout << "Closing claw..." << hwlib::endlRet;
+
                 claw.close();
+                
+                hwlib::wait_ms(2000);
+                hwlib::cout << "Object released!" << hwlib::endlRet;
             }
 
             state = !state;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@ int main() {
 
     UARTConnection conn(115200, UARTController::ONE);
     hwlib::wait_ms(500);
+    Claw claw(conn, touchSensorLeft, touchSensorRight);
 
     long startMsReceive = hwlib::now_us() / 1000;
     long startMsSend = hwlib::now_us() / 1000;
@@ -38,9 +39,9 @@ int main() {
             conn << "#n P2203\n"; // Getting version
 
             if (state) {
-                conn << "#n M2232 V0\n";
+                claw.open();
             } else {
-                conn << "#n M2232 V1\n";
+                claw.close();
             }
 
             state = !state;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief     FIFO Queue.
- * 
+ *
  * Queue without using the internal heap.
  * Based on the following code: https://github.com/sdesalas/Arduino-Queue.h/blob/master/Queue.h
  * @author    Wiebe van Breukelen, Steven de Salas
@@ -11,19 +11,21 @@
 #ifndef QUEUE_HPP
 #define QUEUE_HPP
 
-template<class T, size_t QUEUE_SIZE>
+#include "wrap-hwlib.hpp"
+
+template <class T, size_t QUEUE_SIZE>
 class Queue {
   private:
     unsigned int _front, _back, _count;
     T _data[QUEUE_SIZE];
-    //int QUEUE_SIZE;
+    // int QUEUE_SIZE;
   public:
-    Queue() { 
-      _front = 0;
-      _back = 0;
-      _count = 0;
-      //QUEUE_SIZE = maxitems;
-      //_data = new T[maxitems + 1]; 
+    Queue() {
+        _front = 0;
+        _back = 0;
+        _count = 0;
+        // QUEUE_SIZE = maxitems;
+        //_data = new T[maxitems + 1];
     }
     inline int count();
     inline int front();
@@ -34,61 +36,59 @@ class Queue {
     void clear();
 };
 
-template<class T, size_t QUEUE_SIZE>
-inline int Queue<T, QUEUE_SIZE>::count() 
-{
-  return _count;
+template <class T, size_t QUEUE_SIZE>
+inline int Queue<T, QUEUE_SIZE>::count() {
+    return _count;
 }
 
-template<class T, size_t QUEUE_SIZE>
-inline int Queue<T, QUEUE_SIZE>::front() 
-{
-  return _front;
+template <class T, size_t QUEUE_SIZE>
+inline int Queue<T, QUEUE_SIZE>::front() {
+    return _front;
 }
 
-template<class T, size_t QUEUE_SIZE>
-inline int Queue<T, QUEUE_SIZE>::back() 
-{
-  return _back;
+template <class T, size_t QUEUE_SIZE>
+inline int Queue<T, QUEUE_SIZE>::back() {
+    return _back;
 }
 
-template<class T, size_t QUEUE_SIZE>
-void Queue<T, QUEUE_SIZE>::push(const T &item)
-{
-  if(_count < QUEUE_SIZE) { // Drops out when full
-    _data[_back++]=item;
-    ++_count;
-    // Check wrap around
-    if (_back > QUEUE_SIZE)
-      _back -= (QUEUE_SIZE + 1);
-  }
+template <class T, size_t QUEUE_SIZE>
+void Queue<T, QUEUE_SIZE>::push(const T &item) {
+    if (_count < QUEUE_SIZE) { // Drops out when full
+        _data[_back++] = item;
+        ++_count;
+        // Check wrap around
+        if (_back > QUEUE_SIZE)
+            _back -= (QUEUE_SIZE + 1);
+    }
 }
 
-template<class T, size_t QUEUE_SIZE>
+template <class T, size_t QUEUE_SIZE>
 T Queue<T, QUEUE_SIZE>::pop() {
-  if(_count <= 0) return T(); // Returns empty
-  else {
-    T result = _data[_front];
-    _front++;
-    --_count;
-    // Check wrap around
-    if (_front > QUEUE_SIZE) 
-      _front -= (QUEUE_SIZE + 1);
-    return result; 
-  }
+    if (_count <= 0)
+        return T(); // Returns empty
+    else {
+        T result = _data[_front];
+        _front++;
+        --_count;
+        // Check wrap around
+        if (_front > QUEUE_SIZE)
+            _front -= (QUEUE_SIZE + 1);
+        return result;
+    }
 }
 
-template<class T, size_t QUEUE_SIZE>
+template <class T, size_t QUEUE_SIZE>
 T Queue<T, QUEUE_SIZE>::peek() {
-  if(_count <= 0) return T(); // Returns empty
-  else return _data[_front];
+    if (_count <= 0)
+        return T(); // Returns empty
+    else
+        return _data[_front];
 }
 
-template<class T, size_t QUEUE_SIZE>
-void Queue<T, QUEUE_SIZE>::clear() 
-{
-  _front = _back;
-  _count = 0;
+template <class T, size_t QUEUE_SIZE>
+void Queue<T, QUEUE_SIZE>::clear() {
+    _front = _back;
+    _count = 0;
 }
 
 #endif

--- a/src/uart_connection.cpp
+++ b/src/uart_connection.cpp
@@ -1,6 +1,7 @@
 #include "uart_connection.hpp"
 
-UARTConnection::UARTConnection(unsigned int baudrate, UARTController controller, bool initializeController) : baudrate(baudrate), controller(controller) {
+UARTConnection::UARTConnection(unsigned int baudrate, UARTController controller, bool initializeController)
+    : baudrate(baudrate), controller(controller) {
     if (initializeController) {
         begin();
     }
@@ -44,7 +45,8 @@ void UARTConnection::begin() {
         hardwareUSART = USART3;
 
         /// Disable PIO control on PD4, PD5 and set up for peripheral B (setting a high bit).
-        /// Section 31.7.24 - http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf
+        /// Section 31.7.24 -
+        /// http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf
         PIOD->PIO_PDR = PIO_PD4;
         PIOD->PIO_ABSR |= PIO_PD4;
         PIOD->PIO_PDR = PIO_PD5;
@@ -63,7 +65,8 @@ void UARTConnection::begin() {
     hardwareUSART->US_BRGR = (5241600u / baudrate);
 
     /// No parity, normal channel mode. Use a 8 bit data field.
-    hardwareUSART->US_MR = UART_MR_PAR_NO | UART_MR_CHMODE_NORMAL | US_MR_CHRL_8_BIT; // Might check if this definition is compatable with USART as well.
+    hardwareUSART->US_MR = UART_MR_PAR_NO | UART_MR_CHMODE_NORMAL |
+                           US_MR_CHRL_8_BIT; // Might check if this definition is compatable with USART as well.
 
     /// Disable the interrupt controller.
     hardwareUSART->US_IDR = 0xFFFFFFFF;
@@ -81,10 +84,10 @@ unsigned int UARTConnection::available() {
     }
 
     /// We use the USART Channel status register to check if there is data available in the receiver buffer.
-    //return (hardwareUSART->US_CSR & 1) != 0;
+    // return (hardwareUSART->US_CSR & 1) != 0;
 
     if ((hardwareUSART->US_CSR & 1) != 0) {
-        //rxBuffer[rxBufferIndex++] = receiveByte();
+        // rxBuffer[rxBufferIndex++] = receiveByte();
         rxBuffer.push(receiveByte());
     }
 
@@ -101,7 +104,7 @@ bool UARTConnection::send(const char b) {
     return true;
 }
 
-bool UARTConnection::send(const char* str) {
+bool UARTConnection::send(const char *str) {
     if (!USARTControllerInitialized) {
         return false;
     }
@@ -113,7 +116,7 @@ bool UARTConnection::send(const char* str) {
     return true;
 }
 
-bool UARTConnection::send(const char* data, size_t length) {
+bool UARTConnection::send(const char *data, size_t length) {
     if (!USARTControllerInitialized) {
         return false;
     }
@@ -121,7 +124,7 @@ bool UARTConnection::send(const char* data, size_t length) {
     for (unsigned int i = 0; i < length; i++) {
         sendByte(data[i]);
     }
-    
+
     return true;
 }
 
@@ -130,9 +133,9 @@ char UARTConnection::receive() {
         return -1;
     }
 
-    //return receiveByte();
+    // return receiveByte();
 
-    return rxBuffer.pop();   
+    return rxBuffer.pop();
 }
 
 void UARTConnection::operator<<(const char *str) {
@@ -153,7 +156,8 @@ bool UARTConnection::isInitialized() {
 
 void UARTConnection::sendByte(const char &b) {
     /// Wait before we can send any more data
-    while (!txReady());
+    while (!txReady())
+        ;
 
     /// Send it!
     hardwareUSART->US_THR = b;

--- a/src/uart_connection.hpp
+++ b/src/uart_connection.hpp
@@ -8,194 +8,193 @@
 #ifndef UART_COMM_HPP
 #define UART_COMM_HPP
 
-#include "wrap-hwlib.hpp"
 #include "queue.hpp"
+#include "wrap-hwlib.hpp"
 
 /**
  * @brief Used to select the UART controllers available on the Arduino Due.
- * 
+ *
  * Pins:
  * One   - 18 and 19
  * Two   - 16 and 17
  * Three - 14 and 15
  */
-enum class UARTController {ONE, TWO, THREE};
+enum class UARTController { ONE, TWO, THREE };
 
 /**
  * @brief Establishes an serial/UART connection using on of the three dedicated serial controllers located on the Arduino Due.
  *
  */
 class UARTConnection {
-public:
+  public:
+    /**
+     * @brief Construct a new UARTConnection object.
+     *
+     * @param baudrate Transmit and receive baudrate.
+     * @param controller Controller used to transmit and receive.
+     *
+     * By default, controller one is selected (pins 18 and 19 on the Arduino Due).
+     *
+     * @param initializeController Initialize the USART controller directly within the object constructor.
+     */
+    UARTConnection(unsigned int baudrate, UARTController controller = UARTController::ONE, bool initializeController = true);
 
-  /**
-   * @brief Construct a new UARTConnection object.
-   * 
-   * @param baudrate Transmit and receive baudrate.
-   * @param controller Controller used to transmit and receive.
-   * 
-   * By default, controller one is selected (pins 18 and 19 on the Arduino Due).
-   * 
-   * @param initializeController Initialize the USART controller directly within the object constructor.
-   */
-  UARTConnection(unsigned int baudrate, UARTController controller = UARTController::ONE, bool initializeController = true);
+    /**
+     * @brief Begin a UART connection.
+     *
+     * This method initializes the selected USART (universal synchronous and asynchronous receiver-transmitter) controller located
+     * on the Arduino Due. By default, this method is called at object construction, but this can be disabled.
+     *
+     */
+    void begin();
 
-  /**
-   * @brief Begin a UART connection.
-   * 
-   * This method initializes the selected USART (universal synchronous and asynchronous receiver-transmitter) controller located
-   * on the Arduino Due. By default, this method is called at object construction, but this can be disabled.
-   * 
-   */
-  void begin();
+    /**
+     * @brief Check how many bytes are available to read.
+     *
+     * By checking the size of the receive buffer, we determine if new data has arrived.
+     *
+     * @return unsigned int Amount of bytes available to read.
+     */
+    unsigned int available();
 
-  /**
-   * @brief Check how many bytes are available to read.
-   * 
-   * By checking the size of the receive buffer, we determine if new data has arrived.
-   * 
-   * @return unsigned int Amount of bytes available to read.
-   */
-  unsigned int available();
+    /**
+     * @brief Enables the internal USART controller.
+     *
+     */
+    inline void enable();
 
-  /**
-   * @brief Enables the internal USART controller.
-   * 
-   */
-  inline void enable();
+    /**
+     * @brief Disables the internal USART controller.
+     *
+     */
+    inline void disable();
 
-  /**
-   * @brief Disables the internal USART controller.
-   * 
-   */
-  inline void disable();
+    /**
+     * @brief Send a single byte.
+     *
+     * @param c Byte.
+     * @return true Byte send.
+     * @return false Byte has not been send, USART controller not initialized.
+     */
+    bool send(const char c);
 
-  /**
-   * @brief Send a single byte.
-   * 
-   * @param c Byte.
-   * @return true Byte send.
-   * @return false Byte has not been send, USART controller not initialized.
-   */
-  bool send(const char c);
+    /**
+     * @brief Send a string.
+     *
+     * @param str String.
+     * @return true String send.
+     * @return false String has not been send, USART controller not initialized.
+     */
+    bool send(const char *str);
 
-  /**
-   * @brief Send a string.
-   * 
-   * @param str String.
-   * @return true String send.
-   * @return false String has not been send, USART controller not initialized.
-   */
-  bool send(const char *str);
+    /**
+     * @brief Send a array of bytes with a specified length.
+     *
+     * @param data Array of bytes.
+     * @param length Length of array.
+     * @return true Array of bytes send.
+     * @return false Array of bytes has not been send, USART controller not initialized.
+     */
+    bool send(const char *data, size_t length);
 
-  /**
-   * @brief Send a array of bytes with a specified length.
-   * 
-   * @param data Array of bytes.
-   * @param length Length of array.
-   * @return true Array of bytes send.
-   * @return false Array of bytes has not been send, USART controller not initialized.
-   */
-  bool send(const char* data, size_t length);
+    /**
+     * @brief Receive a single byte.
+     *
+     * By popping the first element of the receive buffer, we return a received byte in a FIFO manner.
+     *
+     * @return char Received byte.
+     */
+    char receive();
 
-  /**
-   * @brief Receive a single byte.
-   * 
-   * By popping the first element of the receive buffer, we return a received byte in a FIFO manner.
-   * 
-   * @return char Received byte.
-   */
-  char receive();
+    /**
+     * @brief Checks if the internal USART controller has been initialized.
+     *
+     * @return true Internal USART controller is initialized.
+     * @return false Internal USART has not been initialized. See the begin() method.
+     */
+    bool isInitialized();
 
-  /**
-   * @brief Checks if the internal USART controller has been initialized.
-   * 
-   * @return true Internal USART controller is initialized.
-   * @return false Internal USART has not been initialized. See the begin() method.
-   */
-  bool isInitialized();
+    /**
+     * @brief Send a single byte.
+     *
+     * @param c Byte.
+     */
+    void operator<<(const char c);
 
-  /**
-   * @brief Send a single byte.
-   * 
-   * @param c Byte.
-   */
-  void operator<<(const char c);
+    /**
+     * @brief Send a string.
+     *
+     * @param str String (must be null terminated).
+     */
+    void operator<<(const char *str);
 
-  /**
-   * @brief Send a string.
-   * 
-   * @param str String (must be null terminated).
-   */
-  void operator<<(const char *str);
+    /**
+     * @brief Receive a byte.
+     *
+     * @param c Byte.
+     */
+    void operator>>(char &c);
 
-  /**
-   * @brief Receive a byte.
-   * 
-   * @param c Byte.
-   */
-  void operator>>(char &c);
+    /**
+     * @brief Destroy the UARTConnection object.
+     *
+     * Disables the UART controller to save resources.
+     *
+     */
+    ~UARTConnection();
 
-  /**
-   * @brief Destroy the UARTConnection object.
-   * 
-   * Disables the UART controller to save resources.
-   * 
-   */
-  ~UARTConnection();
+  private:
+    /**
+     * @brief Pointer the access the internal USART controllers.
+     *
+     */
+    Usart *hardwareUSART = nullptr;
 
-private:
-  /**
-   * @brief Pointer the access the internal USART controllers.
-   * 
-   */
-  Usart *hardwareUSART = nullptr;
+    /**
+     * @brief Data baudrate used for sending and receiving.
+     *
+     */
+    unsigned int baudrate;
 
-  /**
-   * @brief Data baudrate used for sending and receiving.
-   * 
-   */
-  unsigned int baudrate;
+    /**
+     * @brief Enumerable type used to select on of the three USART controllers located on the Arduino Due.
+     *
+     */
+    UARTController controller;
 
-  /**
-   * @brief Enumerable type used to select on of the three USART controllers located on the Arduino Due. 
-   * 
-   */
-  UARTController controller;
+    /**
+     * @brief Holds the initialization status of the USART controller.
+     *
+     */
+    bool USARTControllerInitialized = false;
 
-  /**
-   * @brief Holds the initialization status of the USART controller.
-   * 
-   */
-  bool USARTControllerInitialized = false;
+    /**
+     * @brief UART receive buffer.
+     *
+     */
+    Queue<char, 250> rxBuffer;
 
-  /**
-   * @brief UART receive buffer.
-   * 
-   */
-  Queue<char, 250> rxBuffer;
+    /**
+     * @brief Checks if the USART controller reports that the transmitter is ready to send.
+     *
+     * @return true Ready to send.
+     * @return false Not ready to send.
+     */
+    inline bool txReady();
 
-  /**
-   * @brief Checks if the USART controller reports that the transmitter is ready to send.
-   * 
-   * @return true Ready to send.
-   * @return false Not ready to send.
-   */
-  inline bool txReady();
+    /**
+     * @brief Send a byte of the serial connection.
+     *
+     * @param char Byte to send.
+     */
+    void sendByte(const char &b);
 
-  /**
-   * @brief Send a byte of the serial connection.
-   *
-   * @param char Byte to send.
-   */
-  void sendByte(const char &b);
-
-  /**
-   * @brief Receive a single byte by reading the US_RHR register.
-   * 
-   * @return char 
-   */
-  inline char receiveByte();
+    /**
+     * @brief Receive a single byte by reading the US_RHR register.
+     *
+     * @return char
+     */
+    inline char receiveByte();
 };
 
 #endif

--- a/src/wrap-hwlib.cpp
+++ b/src/wrap-hwlib.cpp
@@ -1,4 +1,3 @@
 /// Include hwlib """"header only"""" code.
 #define HWLIB_ONCE
 #include "wrap-hwlib.hpp"
-

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,6 +1,6 @@
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
 #include "catch.hpp"
 
-TEST_CASE( "Example Test Case" ) {
+TEST_CASE("Example Test Case") {
     REQUIRE(10 == 10);
 }


### PR DESCRIPTION
**Note: there aren't any tests written for this feature. As the goal of the feature is to provide a wrapper for the connection to the uArm, there are a lot of registers to be written. It is practically impossible to test this (or the hardware registers should be emulated, which would be a lot of work)**

The goal of this feature is to establish a connection, and so interactions between the uArm Swift Pro and the Arduino Due.

Vertical slice: [Trello Link](https://trello.com/c/opwJKYNh/26-vs2-robot-claw)

### Changes
This feature includes the following changes:
- Integration of the UART library within the Claw class.
- UART connection (sending and receiver) between the uArm Swift Pro and the Arduino Due using the UART library is functioning properly.
- Able to open and close the robotic claw using the ```Claw``` class.
- Able to receive the version of the firmware running on the uArm Swift Pro.
- Better formatting, used the clang-format tool.
- The Gcode parser was removed and integrated within the ```Claw``` class.



